### PR TITLE
Fix: Use correct patch positions in multi image settings

### DIFF
--- a/mplug_owl/processing_mplug_owl.py
+++ b/mplug_owl/processing_mplug_owl.py
@@ -70,7 +70,7 @@ class MplugOwlProcessor(ProcessorMixin):
         
         if text is not None and images is not None:
             encoding["pixel_values"] = images
-            encoding["patch_positions"] = patch_position
+            encoding["patch_positions"] = patch_positions
             return BatchEncoding(data=encoding)
         elif text is not None:
             return BatchEncoding(data=encoding)


### PR DESCRIPTION
In situations where you want to use multiple images the patch positions were not correctly handed over to the model. This PR fixes that.

The pipeline worked for single images, as the value for `patch_position` is always set during the pre-processing loop. 
In the multi-image setting this is not sufficient, as the stacked `patch_positions` tensor is needed.